### PR TITLE
Add an allow_empty option that doesn't convert empty attributes to nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 StripAttributes is an ActiveModel extension that automatically strips all
 attributes of leading and trailing whitespace before validation. If the
-attribute is blank, it strips the value to `nil`.
+attribute is blank, it strips the value to `nil` by default.
 
 It works by adding a before_validation hook to the record.  By default, all
 attributes are stripped of whitespace, but `:only` and `:except`
@@ -43,6 +43,15 @@ end
 # only :shoe, :sock, and :glove attributes will be stripped
 class ConservativePokerPlayer < ActiveRecord::Base
   strip_attributes :only => [:shoe, :sock, :glove]
+end
+```
+
+### Using `allow_empty`
+
+```ruby
+# Empty attributes will not be converted to nil
+class BrokePokerPlayer < ActiveRecord::Base
+  strip_attributes :allow_empty => true
 end
 ```
 

--- a/lib/strip_attributes.rb
+++ b/lib/strip_attributes.rb
@@ -4,10 +4,12 @@ module ActiveModel::Validations::HelperMethods
   # Strips whitespace from model fields and converts blank values to nil.
   def strip_attributes(options = nil)
     before_validation do |record|
+      allow_empty = options.delete(:allow_empty) if options
+
       attributes = StripAttributes.narrow(record.attributes, options)
       attributes.each do |attr, value|
         if value.respond_to?(:strip)
-          record[attr] = (value.blank?) ? nil : value.strip
+          record[attr] = (value.blank? && !allow_empty) ? nil : value.strip
         end
       end
     end
@@ -25,7 +27,7 @@ module StripAttributes
   # Necessary because Rails has removed the narrowing of attributes using :only
   # and :except on Base#attributes
   def self.narrow(attributes, options)
-    if options.nil?
+    if options.nil? || options.empty?
       attributes
     else
       if except = options[:except]

--- a/test/strip_attributes_test.rb
+++ b/test/strip_attributes_test.rb
@@ -31,6 +31,12 @@ class StripExceptThreeMockRecord < Tableless
   strip_attributes :except => [:foo, :bar, :biz]
 end
 
+class StripAllowEmpty < Tableless
+  include MockAttributes
+  strip_attributes :allow_empty => true
+end
+
+
 class StripAttributesTest < MiniTest::Unit::TestCase
   def setup
     @init_params = { :foo => "\tfoo", :bar => "bar \t ", :biz => "\tbiz ", :baz => "", :bang => " " }
@@ -88,5 +94,15 @@ class StripAttributesTest < MiniTest::Unit::TestCase
     assert_equal "\tbiz ",  record.biz
     assert_nil record.baz
     assert_nil record.bang
+  end
+
+  def test_should_strip_and_allow_empty
+    record = StripAllowEmpty.new(@init_params)
+    record.valid?
+    assert_equal "foo", record.foo
+    assert_equal "bar", record.bar
+    assert_equal "biz", record.biz
+    assert_equal "",    record.baz
+    assert_equal "",    record.bang
   end
 end


### PR DESCRIPTION
Pretty much the same as #5 but with a different option name.

This is needed in a project I'm working on that has `default(""), not null` database fields :-/
