### PR TITLE
Strip duplicate spaces within a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ class BrokePokerPlayer < ActiveRecord::Base
 end
 ```
 
+### Using `collapse_spaces`
+
+```ruby
+# Sequential spaces in attributes will be collapsed to one space
+class EloquentPokerPlayer < ActiveRecord::Base
+  strip_attributes :collapse_spaces => true
+end
+```
+
 ## Usage Patterns
 
 ### Other ORMs implementing `ActiveModel`

--- a/lib/strip_attributes.rb
+++ b/lib/strip_attributes.rb
@@ -4,13 +4,22 @@ module ActiveModel::Validations::HelperMethods
   # Strips whitespace from model fields and converts blank values to nil.
   def strip_attributes(options = nil)
     before_validation do |record|
-      allow_empty = options.delete(:allow_empty) if options
+      if options
+        allow_empty     = options.delete(:allow_empty)
+        collapse_spaces = options.delete(:collapse_spaces)
+      end
 
       attributes = StripAttributes.narrow(record.attributes, options)
       attributes.each do |attr, value|
         if value.respond_to?(:strip)
-          record[attr] = (value.blank? && !allow_empty) ? nil : value.strip
+          value = (value.blank? && !allow_empty) ? nil : value.strip
         end
+
+        if collapse_spaces && value.respond_to?(:squeeze!)
+          value.squeeze!(' ')
+        end
+
+        record[attr] = value
       end
     end
   end

--- a/test/strip_attributes_test.rb
+++ b/test/strip_attributes_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 module MockAttributes
   def self.included(base)
-    base.attributes :foo, :bar, :biz, :baz, :bang
+    base.attributes :foo, :bar, :biz, :baz, :bang, :foz
   end
 end
 
@@ -36,10 +36,14 @@ class StripAllowEmpty < Tableless
   strip_attributes :allow_empty => true
 end
 
+class CollapseDuplicateSpaces < Tableless
+  include MockAttributes
+  strip_attributes :collapse_spaces => true
+end
 
 class StripAttributesTest < MiniTest::Unit::TestCase
   def setup
-    @init_params = { :foo => "\tfoo", :bar => "bar \t ", :biz => "\tbiz ", :baz => "", :bang => " " }
+    @init_params = { :foo => "\tfoo", :bar => "bar \t ", :biz => "\tbiz ", :baz => "", :bang => " ", :foz => " foz  foz" }
   end
 
   def test_should_exist
@@ -49,9 +53,10 @@ class StripAttributesTest < MiniTest::Unit::TestCase
   def test_should_strip_all_fields
     record = StripAllMockRecord.new(@init_params)
     record.valid?
-    assert_equal "foo", record.foo
-    assert_equal "bar", record.bar
-    assert_equal "biz", record.biz
+    assert_equal "foo",      record.foo
+    assert_equal "bar",      record.bar
+    assert_equal "biz",      record.biz
+    assert_equal "foz  foz", record.foz
     assert_nil record.baz
     assert_nil record.bang
   end
@@ -59,29 +64,32 @@ class StripAttributesTest < MiniTest::Unit::TestCase
   def test_should_strip_only_one_field
     record = StripOnlyOneMockRecord.new(@init_params)
     record.valid?
-    assert_equal "foo",     record.foo
-    assert_equal "bar \t ", record.bar
-    assert_equal "\tbiz ",  record.biz
-    assert_equal "",        record.baz
-    assert_equal " ",       record.bang
+    assert_equal "foo",      record.foo
+    assert_equal "bar \t ",  record.bar
+    assert_equal "\tbiz ",   record.biz
+    assert_equal " foz  foz", record.foz
+    assert_equal "",         record.baz
+    assert_equal " ",        record.bang
   end
 
   def test_should_strip_only_three_fields
     record = StripOnlyThreeMockRecord.new(@init_params)
     record.valid?
-    assert_equal "foo", record.foo
-    assert_equal "bar", record.bar
-    assert_equal "biz", record.biz
-    assert_equal "",    record.baz
-    assert_equal " ",   record.bang
+    assert_equal "foo",      record.foo
+    assert_equal "bar",      record.bar
+    assert_equal "biz",      record.biz
+    assert_equal " foz  foz", record.foz
+    assert_equal "",         record.baz
+    assert_equal " ",        record.bang
   end
 
   def test_should_strip_all_except_one_field
     record = StripExceptOneMockRecord.new(@init_params)
     record.valid?
-    assert_equal "\tfoo", record.foo
-    assert_equal "bar",   record.bar
-    assert_equal "biz",   record.biz
+    assert_equal "\tfoo",    record.foo
+    assert_equal "bar",      record.bar
+    assert_equal "biz",      record.biz
+    assert_equal "foz  foz", record.foz
     assert_nil record.baz
     assert_nil record.bang
   end
@@ -89,9 +97,10 @@ class StripAttributesTest < MiniTest::Unit::TestCase
   def test_should_strip_all_except_three_fields
     record = StripExceptThreeMockRecord.new(@init_params)
     record.valid?
-    assert_equal "\tfoo",   record.foo
-    assert_equal "bar \t ", record.bar
-    assert_equal "\tbiz ",  record.biz
+    assert_equal "\tfoo",    record.foo
+    assert_equal "bar \t ",  record.bar
+    assert_equal "\tbiz ",   record.biz
+    assert_equal "foz  foz", record.foz
     assert_nil record.baz
     assert_nil record.bang
   end
@@ -99,10 +108,22 @@ class StripAttributesTest < MiniTest::Unit::TestCase
   def test_should_strip_and_allow_empty
     record = StripAllowEmpty.new(@init_params)
     record.valid?
-    assert_equal "foo", record.foo
-    assert_equal "bar", record.bar
-    assert_equal "biz", record.biz
-    assert_equal "",    record.baz
-    assert_equal "",    record.bang
+    assert_equal "foo",      record.foo
+    assert_equal "bar",      record.bar
+    assert_equal "biz",      record.biz
+    assert_equal "foz  foz", record.foz
+    assert_equal "",         record.baz
+    assert_equal "",         record.bang
+  end
+
+  def test_should_collapse_duplicate_spaces
+    record = CollapseDuplicateSpaces.new(@init_params)
+    record.valid?
+    assert_equal "foo",     record.foo
+    assert_equal "bar",     record.bar
+    assert_equal "biz",     record.biz
+    assert_equal "foz foz", record.foz
+    assert_equal nil,       record.baz
+    assert_equal nil,       record.bang
   end
 end


### PR DESCRIPTION
new option :strip_duplicate_spaces must be explicitly set to true
