### PR TITLE
Fix expectation message in rspec

### DIFF
--- a/lib/strip_attributes/matchers.rb
+++ b/lib/strip_attributes/matchers.rb
@@ -60,6 +60,7 @@ module StripAttributes
       def expectation(past = true)
         expectation = past ? "stripped" : "strip"
         expectation += past ? " and collapsed" : " and collapse" if @options[:collapse_spaces]
+        expectation
       end
     end
   end


### PR DESCRIPTION
Occurs if you don't collapse_spaces
