### PR TITLE
Handle Unicode whitespace and invisible characters

### DIFF
--- a/lib/strip_attributes.rb
+++ b/lib/strip_attributes.rb
@@ -20,6 +20,7 @@ end
 
 module StripAttributes
   VALID_OPTIONS = [:only, :except, :allow_empty, :collapse_spaces, :regex]
+  MULTIBYTE_SUPPORTED = "\u0020" == " "
 
   # Necessary because Rails has removed the narrowing of attributes using :only
   # and :except on Base#attributes
@@ -55,19 +56,21 @@ module StripAttributes
           value.gsub!(regex, '')
         end
 
-        # Remove leading and trailing Unicode invisible and whitespace characters.
-        # The POSIX character class [:space:] corresponds to the Unicode class Z
-        # ("separator"). We also include the following characters from Unicode class
-        # C ("control"), which are spaces or invisible characters that make no
-        # sense at the start or end of a string:
-        #   U+180E MONGOLIAN VOWEL SEPARATOR
-        #   U+200B ZERO WIDTH SPACE
-        #   U+200C ZERO WIDTH NON-JOINER
-        #   U+200D ZERO WIDTH JOINER
-        #   U+2060 WORD JOINER
-        #   U+FEFF ZERO WIDTH NO-BREAK SPACE
-        if value.respond_to?(:gsub!)
-          value.gsub!(/\A[[:space:]\u180E\u200B\u200C\u200D\u2060\uFEFF]+|[[:space:]\u180E\u200B\u200C\u200D\u2060\uFEFF]+\z/, '')
+        if MULTIBYTE_SUPPORTED
+          # Remove leading and trailing Unicode invisible and whitespace characters.
+          # The POSIX character class [:space:] corresponds to the Unicode class Z
+          # ("separator"). We also include the following characters from Unicode class
+          # C ("control"), which are spaces or invisible characters that make no
+          # sense at the start or end of a string:
+          #   U+180E MONGOLIAN VOWEL SEPARATOR
+          #   U+200B ZERO WIDTH SPACE
+          #   U+200C ZERO WIDTH NON-JOINER
+          #   U+200D ZERO WIDTH JOINER
+          #   U+2060 WORD JOINER
+          #   U+FEFF ZERO WIDTH NO-BREAK SPACE
+          if value.respond_to?(:gsub!)
+            value.gsub!(/\A[[:space:]\u180E\u200B\u200C\u200D\u2060\uFEFF]+|[[:space:]\u180E\u200B\u200C\u200D\u2060\uFEFF]+\z/, '')
+          end
         end
 
         if collapse_spaces && value.respond_to?(:squeeze!)

--- a/test/strip_attributes_test.rb
+++ b/test/strip_attributes_test.rb
@@ -184,6 +184,8 @@ class StripAttributesTest < MiniTest::Unit::TestCase
   end  
 
   def test_strip_unicode
+    # This feature only works if multi-byte characters are supported by Ruby
+    return if "\u0020" != " "
     # U200A - HAIR SPACE
     # U200B - ZERO WIDTH SPACE
     record = StripOnlyOneMockRecord.new({:foo => "\u200A\u200B foo\u200A\u200B "})


### PR DESCRIPTION
Unicode defines a number of whitespace and invisible characters that strip_attributes does not currently strip. This pull request adds support for stripping these.

I created the list based off of [this](http://www.cs.tut.fi/~jkorpela/chars/spaces.html) and [this](http://unicode.org/Public/UNIDATA/PropList.txt). I'm not a Unicode expert so it's possible I missed some or included some I shouldn't have.
