### PR TITLE
Add support for stripping hash values

### DIFF
--- a/lib/strip_attributes.rb
+++ b/lib/strip_attributes.rb
@@ -19,7 +19,7 @@ module ActiveModel::Validations::HelperMethods
 end
 
 module StripAttributes
-  VALID_OPTIONS = [:only, :except, :allow_empty, :collapse_spaces, :regex]
+  VALID_OPTIONS = [:only, :except, :allow_empty, :collapse_spaces, :regex, :strip_hash_values]
   MULTIBYTE_SUPPORTED = "\u0020" == " "
 
   # Necessary because Rails has removed the narrowing of attributes using :only
@@ -37,48 +37,60 @@ module StripAttributes
   end
 
   def self.strip(record, options)
-      attributes = self.narrow(record.attributes, options)
+    attributes = self.narrow(record.attributes, options)
 
-      if options
-        allow_empty     = options[:allow_empty]
-        collapse_spaces = options[:collapse_spaces]
-        regex           = options[:regex]
+    if options
+      strip_hash_values = options[:strip_hash_values] 
+    end
+
+    attributes.map do |attr, value|
+      original_value = value
+      if :strip_hash_values && value.respond_to?(:values)
+        modified_key_value_pairs = value.map { |k,v| [k, strip_value(v,options)] }
+        value = Hash[modified_key_value_pairs]
+      else
+        value = strip_value(value, options)
       end
+      record[attr] = value if original_value != value
+    end
+  end
+  
+  def self.strip_value(value, options)
+    if options
+      allow_empty     = options[:allow_empty]
+      collapse_spaces = options[:collapse_spaces]
+      regex           = options[:regex]
+    end
+    
+    if value.respond_to?(:strip)
+      value = (value.blank? && !allow_empty) ? nil : value.strip
+    end
 
-      attributes.each do |attr, value|
-        original_value = value
+    if regex && value.respond_to?(:gsub!)
+      value.gsub!(regex, '')
+    end
 
-        if value.respond_to?(:strip)
-          value = (value.blank? && !allow_empty) ? nil : value.strip
-        end
-
-        if regex && value.respond_to?(:gsub!)
-          value.gsub!(regex, '')
-        end
-
-        if MULTIBYTE_SUPPORTED
-          # Remove leading and trailing Unicode invisible and whitespace characters.
-          # The POSIX character class [:space:] corresponds to the Unicode class Z
-          # ("separator"). We also include the following characters from Unicode class
-          # C ("control"), which are spaces or invisible characters that make no
-          # sense at the start or end of a string:
-          #   U+180E MONGOLIAN VOWEL SEPARATOR
-          #   U+200B ZERO WIDTH SPACE
-          #   U+200C ZERO WIDTH NON-JOINER
-          #   U+200D ZERO WIDTH JOINER
-          #   U+2060 WORD JOINER
-          #   U+FEFF ZERO WIDTH NO-BREAK SPACE
-          if value.respond_to?(:gsub!)
-            value.gsub!(/\A[[:space:]\u180E\u200B\u200C\u200D\u2060\uFEFF]+|[[:space:]\u180E\u200B\u200C\u200D\u2060\uFEFF]+\z/, '')
-          end
-        end
-
-        if collapse_spaces && value.respond_to?(:squeeze!)
-          value.squeeze!(' ')
-        end
-
-        record[attr] = value if original_value != value
+    if MULTIBYTE_SUPPORTED
+      # Remove leading and trailing Unicode invisible and whitespace characters.
+      # The POSIX character class [:space:] corresponds to the Unicode class Z
+      # ("separator"). We also include the following characters from Unicode class
+      # C ("control"), which are spaces or invisible characters that make no
+      # sense at the start or end of a string:
+      #   U+180E MONGOLIAN VOWEL SEPARATOR
+      #   U+200B ZERO WIDTH SPACE
+      #   U+200C ZERO WIDTH NON-JOINER
+      #   U+200D ZERO WIDTH JOINER
+      #   U+2060 WORD JOINER
+      #   U+FEFF ZERO WIDTH NO-BREAK SPACE
+      if value.respond_to?(:gsub!)
+        value.gsub!(/\A[[:space:]\u180E\u200B\u200C\u200D\u2060\uFEFF]+|[[:space:]\u180E\u200B\u200C\u200D\u2060\uFEFF]+\z/, '')
       end
+    end
+
+    if collapse_spaces && value.respond_to?(:squeeze!)
+      value.squeeze!(' ')
+    end    
+    value
   end
 
   def self.validate_options(options)

--- a/test/strip_attributes_test.rb
+++ b/test/strip_attributes_test.rb
@@ -8,6 +8,7 @@ module MockAttributes
     base.attribute :baz
     base.attribute :bang
     base.attribute :foz
+    base.attribute :fox_hash
   end
 end
 
@@ -46,6 +47,7 @@ class CollapseDuplicateSpaces < Tableless
   strip_attributes :collapse_spaces => true
 end
 
+
 class CoexistWithOtherValidations < Tableless
   attribute :number, :type => Integer
 
@@ -61,9 +63,21 @@ class StripRegexMockRecord < Tableless
   strip_attributes :regex => /[\^\%&\*]/
 end
 
+class StripHashValues < Tableless
+  include MockAttributes
+  strip_attributes :strip_hash_values => true 
+end
+
 class StripAttributesTest < MiniTest::Unit::TestCase
   def setup
-    @init_params = { :foo => "\tfoo", :bar => "bar \t ", :biz => "\tbiz ", :baz => "", :bang => " ", :foz => " foz  foz" }
+    @init_params = { :foo => "\tfoo", 
+                     :bar => "bar \t ", 
+                     :biz => "\tbiz ", 
+                     :baz => "", 
+                     :bang => " ", 
+                     :foz => " foz  foz",
+                     :fox_hash => {:foo => "    foz" } }
+                     
   end
 
   def test_should_exist
@@ -191,5 +205,11 @@ class StripAttributesTest < MiniTest::Unit::TestCase
     record = StripOnlyOneMockRecord.new({:foo => "\u200A\u200B foo\u200A\u200B "})
     record.valid?
     assert_equal "foo",      record.foo
+  end
+  
+  def test_strip_hash_values
+    record = StripHashValues.new(@init_params)    
+    record.valid?
+    assert_equal 'foz', record.fox_hash[:foo]
   end
 end


### PR DESCRIPTION
Added a new option strip_hash_values that can be used if the caller wants to strip values in hash attributes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/rmm5t/strip_attributes/25)
<!-- Reviewable:end -->
