### PR TITLE
Avoid Encoding::CompatibilityError when handling binary column

### DIFF
--- a/lib/strip_attributes.rb
+++ b/lib/strip_attributes.rb
@@ -70,8 +70,9 @@ module StripAttributes
       #   U+200D ZERO WIDTH JOINER
       #   U+2060 WORD JOINER
       #   U+FEFF ZERO WIDTH NO-BREAK SPACE
-      if value.respond_to?(:gsub!)
-        value.gsub!(/\A[[:space:]\u180E\u200B\u200C\u200D\u2060\uFEFF]+|[[:space:]\u180E\u200B\u200C\u200D\u2060\uFEFF]+\z/, '')
+      regex = /\A[[:space:]\u180E\u200B\u200C\u200D\u2060\uFEFF]+|[[:space:]\u180E\u200B\u200C\u200D\u2060\uFEFF]+\z/
+      if value.respond_to?(:gsub!) && Encoding.compatible?(value, regex)
+        value.gsub!(regex, '')
       end
     elsif value.respond_to?(:strip!)
       value.strip!

--- a/test/strip_attributes_test.rb
+++ b/test/strip_attributes_test.rb
@@ -267,7 +267,10 @@ class StripAttributesTest < Minitest::Test
       return if "\u0020" != " "
       # U200A - HAIR SPACE
       # U200B - ZERO WIDTH SPACE
+      # U20AC - EURO SIGN
+
       assert_equal "foo", StripAttributes.strip("\u200A\u200B foo\u200A\u200B ")
+      assert_equal "foo\u20AC".force_encoding("ASCII-8BIT"), StripAttributes.strip("foo\u20AC ".force_encoding("ASCII-8BIT"))
     end
   end
 end


### PR DESCRIPTION
We started using strip_attributes in our project and found this runtime error when we try to strip a binary column. In PostgreSQL the type is called BYTEA.

```
Encoding::CompatibilityError: incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string)
```

Thank you for writing this gem!