### PR TITLE
Make compatible with Mobility translation gem

### DIFF
--- a/lib/strip_attributes.rb
+++ b/lib/strip_attributes.rb
@@ -51,7 +51,7 @@ module StripAttributes
     attributes.each do |attr, value|
       original_value = value
       value = strip_string(value, options)
-      record[attr] = value if original_value != value
+      record.send "#{attr}=", value if original_value != value
     end
 
     record


### PR DESCRIPTION
https://github.com/shioyama/mobility/ is a very nice translation gem. Sadly it doesn't play well with `strip_attributes`. This little change fixes it. Tests pass. All fine in my opinion.

See https://github.com/shioyama/mobility/issues/97.