### PR TITLE
Be Rails 6.0.0.beta1 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ gemfile:
   - gemfiles/activemodel-4.2.gemfile
   - gemfiles/activemodel-5.1.gemfile
   - gemfiles/activemodel-5.2.gemfile
+  - gemfiles/activemodel-6.0.gemfile
   - gemfiles/activemodel-master.gemfile
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
 gemfile:
   - Gemfile
   - gemfiles/activemodel-3.2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ gemfile:
   - gemfiles/activemodel-6.0.gemfile
   - gemfiles/activemodel-master.gemfile
 matrix:
+  exclude:
+    - rvm: 2.3
+      gemfile: gemfiles/activemodel-6.0.gemfile
+    - rvm: 2.4
+      gemfile: gemfiles/activemodel-6.0.gemfile
   allow_failures:
     - gemfile: gemfiles/activemodel-master.gemfile
   fast_finish: true

--- a/gemfiles/activemodel-6.0.gemfile
+++ b/gemfiles/activemodel-6.0.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "activemodel", ">= 6.0.0.beta1", "< 7.0"
+
+gemspec path: "../"

--- a/strip_attributes.gemspec
+++ b/strip_attributes.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files -- {test,spec}/*`.split("\n")
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activemodel", ">= 3.0", "< 6.0"
+  spec.add_runtime_dependency "activemodel", ">= 3.0", "< 7.0"
   spec.add_development_dependency "active_attr", "~> 0.10"
   spec.add_development_dependency "minitest", ">= 5.0", "< 6.0"
   spec.add_development_dependency "minitest-matchers_vaccine", "~> 1.0" unless ENV["SKIP_VACCINE"]


### PR DESCRIPTION
All strip_attributes tests already pass at ActiveModel 6.0.0.beta1. No patch needed.
I've just adjusted the configurations and checked Travis still have a green build.