### PR TITLE
Regression in 1.9.1: Arrays & Hashes now become nil

### DIFF
--- a/lib/strip_attributes.rb
+++ b/lib/strip_attributes.rb
@@ -49,6 +49,7 @@ module StripAttributes
     attributes = narrow(record.attributes, options)
 
     attributes.each do |attr, value|
+      next unless value.is_a?(String)
       original_value = value
       value = strip_string(value, options)
       record[attr] = value if original_value != value

--- a/test/strip_attributes_test.rb
+++ b/test/strip_attributes_test.rb
@@ -61,6 +61,17 @@ class ReplaceNewLinesAndDuplicateSpaces < Tableless
   strip_attributes replace_newlines: true, collapse_spaces: true
 end
 
+class CoexistWithOtherObjects < Tableless
+  attr_accessor :arr, :hsh, :str
+  strip_attributes
+  def initialize
+    @arr, @hsh, @str = [], {}, "foo "
+  end
+  def attributes
+    {arr: arr, hsh: hsh, str: str}
+  end
+end
+
 class CoexistWithOtherValidations < Tableless
   attribute :number, type: Integer
 
@@ -240,6 +251,14 @@ class StripAttributesTest < Minitest::Test
     assert_equal "fiz \n  fiz", record.fiz
     assert_equal "",            record.baz
     assert_equal "",            record.bang
+  end
+
+  def test_should_allow_other_empty_objects
+    record = CoexistWithOtherObjects.new
+    record.valid?
+    assert_equal [],    record.arr
+    assert_equal({},    record.hsh)
+    assert_equal "foo", record.str
   end
 
   def test_should_coexist_with_other_validations


### PR DESCRIPTION
Hi there! It appears that #47 (released in v1.9.1) causes a change from previous behavior.

In v1.9.0 & prior, converting `.blank?` -> `nil` was implicitly limited to Strings because those were conditional on `if value.respond_to?(:strip)`.

#47 separated the `.blank?` test from `respond_to?(:strip)` which now causes non-Strings, such as Hashes and Arrays, to also be converted to `nil`.

This PR adds a check that an attribute is a String before running `strip_string()`, which matches the prior behavior.

Side note: this would likely allow many of the other `respond_to?()` tests to be dropped, but that seemed out of scope to be including here.