### PR TITLE
Fix matcher description when list of arguments is passed

### DIFF
--- a/lib/strip_attributes/matchers.rb
+++ b/lib/strip_attributes/matchers.rb
@@ -54,7 +54,7 @@ module StripAttributes
       alias_method :negative_failure_message,       :failure_message_when_negated # RSpec 1.1
 
       def description
-        "#{expectation(false)} whitespace from ##{@attribute}"
+        "#{expectation(false)} whitespace from #{@attributes.map {|el| "##{el}" }.to_sentence}"
       end
 
       private


### PR DESCRIPTION
After updating the gem in my project, I realized that I neglected to update the descriptions for the matcher when a list of arguments is passed in (oops!). This very minor change should fix this.

I thought about conditionally having slightly different messages depending on the number of arguments, but opted to just include them all in the description. Note that failure messages are still attribute-specific. I also wasn't sure how to test the _description_ of the test case, so I didn't write a test in this situation and hope that was OK.

Screenshots of the test case descriptions in my project from before & after updating to v1.10.0 included below, showing the issue.

**Before**
<img width="591" alt="Screen Shot 2020-04-01 at 10 01 44 AM" src="https://user-images.githubusercontent.com/2946681/78155791-87c85b00-7403-11ea-8d2a-685d6c2cf321.png">

**After**
<img width="482" alt="Screen Shot 2020-04-01 at 10 01 51 AM" src="https://user-images.githubusercontent.com/2946681/78155837-9282f000-7403-11ea-9663-73203cbf61c9.png">

With this change, the new description _should_ be:

**is expected to strip and collapse whitespace from #title, #expertise, #location, #dream_companies, #dream_job_description, #background, #dream_company_description, and #anything_else**

