### PR TITLE
Fix Ruby deprecation warning

### DIFF
--- a/lib/strip_attributes.rb
+++ b/lib/strip_attributes.rb
@@ -2,11 +2,11 @@ require "active_model"
 
 module ActiveModel::Validations::HelperMethods
   # Strips whitespace from model fields and converts blank values to nil.
-  def strip_attributes(options = {})
-    StripAttributes.validate_options(options)
+  def strip_attributes(**options)
+    StripAttributes.validate_options(**options)
 
     before_validation(options.slice(:if, :unless)) do |record|
-      StripAttributes.strip(record, options)
+      StripAttributes.strip(record, **options)
     end
   end
 end

--- a/strip_attributes.gemspec
+++ b/strip_attributes.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-reporters", ">= 0.14.24"
   spec.add_development_dependency "rake"
 
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.0'
 end


### PR DESCRIPTION
I am getting:
```
ruby/2.7.0/gems/strip_attributes-1.11.0/lib/strip_attributes.rb:8: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
ruby/2.7.0/gems/activemodel-6.0.3.2/lib/active_model/callbacks.rb:130: warning: The called method is defined here
```