### PR TITLE
#61 matcher for the replace_newlines functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ end
 ```ruby
 describe User do
   it { is_expected.to strip_attribute(:name).collapse_spaces }
+  it { is_expected.to strip_attribute(:name).replace_newlines }
   it { is_expected.to strip_attribute :email }
   it { is_expected.to strip_attributes(:name, :email) }
   it { is_expected.not_to strip_attribute :password }
@@ -245,6 +246,7 @@ end
 ```ruby
 class UserTest < ActiveSupport::TestCase
   should strip_attribute(:name).collapse_spaces
+  should strip_attribute(:name).replace_newlines
   should strip_attribute :email
   should strip_attributes(:name, :email)
   should_not strip_attribute :password
@@ -260,6 +262,7 @@ describe User do
 
   it "should strip attributes" do
     must strip_attribute(:name).collapse_spaces
+    must strip_attribute(:name).replace_newlines
     must strip_attribute :email
     must strip_attributes(:name, :email)
     wont strip_attribute :password
@@ -275,6 +278,7 @@ describe User do
   subject { User.new }
 
   must { strip_attribute(:name).collapse_spaces }
+  must { strip_attribute(:name).replace_newlines }
   must { strip_attribute :email }
   must { strip_attributes(:name, :email) }
   wont { strip_attribute :password }

--- a/lib/strip_attributes/matchers.rb
+++ b/lib/strip_attributes/matchers.rb
@@ -33,12 +33,17 @@ module StripAttributes
           @attribute = attribute
           subject.send("#{@attribute}=", " string ")
           subject.valid?
-          subject.send(@attribute) == "string" and collapse_spaces?(subject)
+          subject.send(@attribute) == "string" and collapse_spaces?(subject) and replace_newlines?(subject)
         end
       end
 
       def collapse_spaces
         @options[:collapse_spaces] = true
+        self
+      end
+
+      def replace_newlines
+        @options[:replace_newlines] = true
         self
       end
 
@@ -70,7 +75,16 @@ module StripAttributes
       def expectation(past = true)
         expectation = past ? "stripped" : "strip"
         expectation += past ? " and collapsed" : " and collapse" if @options[:collapse_spaces]
+        expectation += past ? " and replaced" : " and replace" if !@options[:replace_newlines]
         expectation
+      end
+
+      def replace_newlines?(subject)
+        return true if !@options[:replace_newlines]
+
+        subject.send("#{@attribute}=", "string\nstring")
+        subject.valid?
+        subject.send(@attribute) == "string string"
       end
     end
   end

--- a/test/matchers_test.rb
+++ b/test/matchers_test.rb
@@ -18,6 +18,10 @@ class SampleMockRecord < Tableless
   attribute :collapsed
   attribute :uncollapsed
   strip_attributes only: [:collapsed], collapse_spaces: true
+
+  attribute :replaceable
+  attribute :unreplaceable
+  strip_attributes only: [:replaceable], replace_newlines: true
 end
 
 describe SampleMockRecord do
@@ -45,6 +49,14 @@ describe SampleMockRecord do
     it "should not collapse other attributes" do
       wont strip_attribute(:uncollapsed).collapse_spaces
     end
+
+    it "should replace replaceable attributes" do
+      must strip_attribute(:replaceable).replace_newlines
+    end
+
+    it "should not replace on other attributes" do
+      wont strip_attribute(:unreplaceable).replace_newlines
+    end
   else
       must { strip_attribute :stripped1 }
       must { strip_attribute :stripped2 }
@@ -55,6 +67,9 @@ describe SampleMockRecord do
 
       must { strip_attribute(:collapsed).collapse_spaces }
       wont { strip_attribute(:uncollapsed).collapse_spaces }
+
+      must { strip_attribute(:replaceable).replace_newlines }
+      wont { strip_attribute(:unreplaceable).replace_newlines }
   end
 
   it "should fail when testing for strip on an unstripped attribute" do
@@ -87,6 +102,24 @@ describe SampleMockRecord do
   it "should fail when testing for no collapse on a collapsed attribute" do
     begin
       assert_wont collapse_attribute(:collapsed)
+      assert false
+    rescue
+      assert true
+    end
+  end
+
+  it "should fail when testing for replacement on an unreplaceable attribute" do
+    begin
+      assert_must replace_newlines(:unreplaceable)
+      assert false
+    rescue
+      assert true
+    end
+  end
+
+  it "should fail when testing for no replacement on a replaceable attribute" do
+    begin
+      assert_wont replace_newlines(:replaceable)
       assert false
     rescue
       assert true


### PR DESCRIPTION
This PR is for #61 

I added a matcher for the replace_newlines functionality and added  tests following the same pattern as for the strip_attribute matcher. I updated README with example of using the matcher.

Appreciate any feedback.