### PR TITLE
Prevent String mutation

### DIFF
--- a/lib/strip_attributes.rb
+++ b/lib/strip_attributes.rb
@@ -52,7 +52,7 @@ module StripAttributes
 
   def self.strip_string(value, options = {})
     return value unless value.is_a?(String)
-    return value if value.frozen?
+    value = value.dup
 
     allow_empty      = options[:allow_empty]
     collapse_spaces  = options[:collapse_spaces]

--- a/test/strip_attributes_test.rb
+++ b/test/strip_attributes_test.rb
@@ -204,10 +204,12 @@ class StripAttributesTest < Minitest::Test
     assert_equal "",            record.bang
   end
 
-  def test_should_skip_frozen_values
-    record = StripAllMockRecord.new(frozen: " ice ".freeze)
+  def test_should_not_mutate_values
+    record = StripAllMockRecord.new(foo: " foo ")
+    old_value = record.foo
     record.valid?
-    assert_equal " ice ", record.frozen
+    assert_equal "foo",        record.foo
+    refute_equal old_value,    record.foo
   end
 
   def test_should_collapse_duplicate_spaces


### PR DESCRIPTION
We had a bug with frozen Strings. It's not clear that the stripping was also mutating, and it was failing silently on the frozen String. I figure there are basically 2 ways to go here: raise on the frozen String or dup the String.

As I see no reason to expect that this method mutates the String (ie it's not a bang method like the gsub! that actually mutates), the dup method seems appropriate.