### PR TITLE
Use `assign_attributes` to change attributes

### DIFF
--- a/lib/strip_attributes.rb
+++ b/lib/strip_attributes.rb
@@ -44,7 +44,7 @@ module StripAttributes
     attributes.each do |attr, value|
       original_value = value
       value = strip_string(value, options)
-      record[attr] = value if original_value != value
+      record.assign_attributes(attr => value) if original_value != value
     end
 
     record

--- a/strip_attributes.gemspec
+++ b/strip_attributes.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_runtime_dependency "activemodel", ">= 3.0", "< 8.0"
-  spec.add_development_dependency "active_attr", "~> 0.15"
   spec.add_development_dependency "minitest", ">= 5.0", "< 6.0"
   spec.add_development_dependency "minitest-matchers_vaccine", "~> 1.0" unless ENV["SKIP_VACCINE"]
   spec.add_development_dependency "minitest-reporters", ">= 0.14.24"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,14 +6,12 @@ else
   Minitest::Reporters.use! Minitest::Reporters::ProgressReporter.new
 end
 
-require "active_attr"
 require "strip_attributes"
 
 class Tableless
-  include ActiveAttr::BasicModel
-  include ActiveAttr::TypecastedAttributes
-  include ActiveAttr::Serialization
-
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Validations
   include ActiveModel::Validations::Callbacks
 end
 


### PR DESCRIPTION
This allows the gem to support `ActiveModel::Model` as well as `ActiveRecord`.