### PR TITLE
Enabled frozen string literal compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["3.2", "3.3"]
+        ruby: ["3.2", "3.3", "3.4.0-preview2"]
         gemfile:
           - activemodel-7.1
           - activemodel-7.2
@@ -26,6 +26,7 @@ jobs:
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
+      RUBYOPT: --enable=frozen-string-literal --debug=frozen-string-literal
     steps:
       # https://github.com/marketplace/actions/checkout
       - uses: actions/checkout@v4

--- a/lib/strip_attributes.rb
+++ b/lib/strip_attributes.rb
@@ -29,6 +29,8 @@ module StripAttributes
   MULTIBYTE_SPACE = /[[:space:]#{MULTIBYTE_WHITE}]/.freeze
   MULTIBYTE_BLANK = /[[:blank:]#{MULTIBYTE_WHITE}]/.freeze
   MULTIBYTE_SUPPORTED = "\u0020" == " "
+  EMPTY_STRING = "".freeze
+  SINGLE_SPACE = " ".freeze
 
   def self.strip(record_or_string, options = {})
     if record_or_string.respond_to?(:attributes)
@@ -59,7 +61,7 @@ module StripAttributes
     replace_newlines = options[:replace_newlines]
     regex            = options[:regex]
 
-    value.gsub!(regex, "") if regex
+    value.gsub!(regex, EMPTY_STRING) if regex
 
     if MULTIBYTE_SUPPORTED && Encoding.compatible?(value, MULTIBYTE_SPACE)
       value.gsub!(/\A#{MULTIBYTE_SPACE}+|#{MULTIBYTE_SPACE}+\z/, "")
@@ -67,13 +69,13 @@ module StripAttributes
       value.strip!
     end
 
-    value.gsub!(/[\r\n]+/, " ") if replace_newlines
+    value.gsub!(/[\r\n]+/, SINGLE_SPACE) if replace_newlines
 
     if collapse_spaces
       if MULTIBYTE_SUPPORTED && Encoding.compatible?(value, MULTIBYTE_BLANK)
-        value.gsub!(/#{MULTIBYTE_BLANK}+/, " ")
+        value.gsub!(/#{MULTIBYTE_BLANK}+/, SINGLE_SPACE)
       else
-        value.squeeze!(" ")
+        value.squeeze!(SINGLE_SPACE)
       end
     end
 

--- a/lib/strip_attributes/matchers.rb
+++ b/lib/strip_attributes/matchers.rb
@@ -31,7 +31,7 @@ module StripAttributes
       def matches?(subject)
         @attributes.all? do |attribute|
           @attribute = attribute
-          subject.send("#{@attribute}=", " string ")
+          subject.send("#{@attribute}=", +" string ")
           subject.valid?
           subject.send(@attribute) == "string" and collapse_spaces?(subject) and replace_newlines?(subject)
         end
@@ -67,7 +67,7 @@ module StripAttributes
       def collapse_spaces?(subject)
         return true if !@options[:collapse_spaces]
 
-        subject.send("#{@attribute}=", " string    string ")
+        subject.send("#{@attribute}=", +" string    string ")
         subject.valid?
         subject.send(@attribute) == "string string"
       end
@@ -82,7 +82,7 @@ module StripAttributes
       def replace_newlines?(subject)
         return true if !@options[:replace_newlines]
 
-        subject.send("#{@attribute}=", "string\nstring")
+        subject.send("#{@attribute}=", +"string\nstring")
         subject.valid?
         subject.send(@attribute) == "string string"
       end

--- a/test/strip_attributes_test.rb
+++ b/test/strip_attributes_test.rb
@@ -66,7 +66,7 @@ class CoexistWithOtherObjects < Tableless
   attr_accessor :arr, :hsh, :str
   strip_attributes
   def initialize
-    @arr, @hsh, @str = [], {}, "foo "
+    @arr, @hsh, @str = [], {}, +"foo "
   end
   def attributes
     {arr: arr, hsh: hsh, str: str}
@@ -114,15 +114,15 @@ end
 class StripAttributesTest < Minitest::Test
   def setup
     @init_params = {
-      foo:  "\tfoo",
-      bar:  "bar \t ",
-      biz:  "\tbiz ",
-      baz:  "",
-      bang: " ",
-      foz:  " foz  foz",
-      fiz:  "fiz \n  fiz",
-      qax:  "\n\t ",
-      qux:  "\u200B"
+      foo:  +"\tfoo",
+      bar:  +"bar \t ",
+      biz:  +"\tbiz ",
+      baz:  +"",
+      bang: +" ",
+      foz:  +" foz  foz",
+      fiz:  +"fiz \n  fiz",
+      qax:  +"\n\t ",
+      qux:  +"\u200B"
     }
   end
 
@@ -285,7 +285,7 @@ class StripAttributesTest < Minitest::Test
 
   def test_should_strip_regex
     record = StripRegexMockRecord.new
-    record.assign_attributes(@init_params.merge(foo: "^%&*abc  "))
+    record.assign_attributes(@init_params.merge(foo: +"^%&*abc  "))
     record.valid?
     assert_equal "abc",        record.foo
     assert_equal "bar",        record.bar
@@ -294,7 +294,7 @@ class StripAttributesTest < Minitest::Test
   def test_should_strip_unicode
     skip "multi-byte characters not supported by this version of Ruby" unless StripAttributes::MULTIBYTE_SUPPORTED
 
-    record = StripOnlyOneMockRecord.new({foo: "\u200A\u200B foo\u200A\u200B\u00A0 "})
+    record = StripOnlyOneMockRecord.new({foo: +"\u200A\u200B foo\u200A\u200B\u00A0 "})
     record.valid?
     assert_equal "foo",      record.foo
   end
@@ -373,42 +373,42 @@ class StripAttributesTest < Minitest::Test
 
   class ClassMethodsTest < Minitest::Test
     def test_should_strip_whitespace
-      assert_nil StripAttributes.strip("")
-      assert_nil StripAttributes.strip(" \t ")
-      assert_equal "thirty six", StripAttributes.strip(" thirty six \t \n")
+      assert_nil StripAttributes.strip(+"")
+      assert_nil StripAttributes.strip(+" \t ")
+      assert_equal "thirty six", StripAttributes.strip(+" thirty six \t \n")
     end
 
     def test_should_allow_empty
-      assert_equal "", StripAttributes.strip("", allow_empty: true)
-      assert_equal "", StripAttributes.strip(" \t ", allow_empty: true)
+      assert_equal "", StripAttributes.strip(+"", allow_empty: true)
+      assert_equal "", StripAttributes.strip(+" \t ", allow_empty: true)
     end
 
     def test_should_collapse_spaces
-      assert_equal "1 2 3", StripAttributes.strip(" 1   2   3\t ", collapse_spaces: true)
+      assert_equal "1 2 3", StripAttributes.strip(+" 1   2   3\t ", collapse_spaces: true)
     end
 
     def test_should_collapse_multibyte_spaces
-      assert_equal "1 2 3", StripAttributes.strip(" 1 \u00A0  2\u00A03\t ", collapse_spaces: true)
+      assert_equal "1 2 3", StripAttributes.strip(+" 1 \u00A0  2\u00A03\t ", collapse_spaces: true)
     end
 
     def test_should_replace_newlines
-      assert_equal "1 2", StripAttributes.strip("1\n2", replace_newlines: true)
-      assert_equal "1 2", StripAttributes.strip("1\r\n2", replace_newlines: true)
-      assert_equal "1 2", StripAttributes.strip("1\r2", replace_newlines: true)
+      assert_equal "1 2", StripAttributes.strip(+"1\n2", replace_newlines: true)
+      assert_equal "1 2", StripAttributes.strip(+"1\r\n2", replace_newlines: true)
+      assert_equal "1 2", StripAttributes.strip(+"1\r2", replace_newlines: true)
     end
 
     def test_should_strip_regex
-      assert_equal "abc", StripAttributes.strip("^%&*abc  ^  ", regex: /[\^\%&\*]/)
+      assert_equal "abc", StripAttributes.strip(+"^%&*abc  ^  ", regex: /[\^\%&\*]/)
     end
 
     def test_should_keep_only_alphanumerics
-      nickname = " funky BAT-2009"
+      nickname = +" funky BAT-2009"
       assert_equal "funkyBAT-2009", StripAttributes.strip(nickname, regex: /[^[:alnum:]_-]/)
     end
 
     def test_should_strip_trailing_whitespace
       messy_code =
-        "const hello = (name) => {      \n" +
+        +"const hello = (name) => {      \n" +
         "  if (name === 'voldemort') return; \n" +
         "  \n" +
         "  console.log(`Hello ${name}!`); \t \t \n" +
@@ -427,8 +427,8 @@ class StripAttributesTest < Minitest::Test
     def test_should_strip_unicode
       skip "multi-byte characters not supported by this version of Ruby" unless StripAttributes::MULTIBYTE_SUPPORTED
 
-      assert_equal "foo", StripAttributes.strip("\u200A\u200B foo\u200A\u200B ")
-      assert_equal "foo\u20AC".force_encoding("ASCII-8BIT"), StripAttributes.strip("foo\u20AC ".force_encoding("ASCII-8BIT"))
+      assert_equal "foo", StripAttributes.strip(+"\u200A\u200B foo\u200A\u200B ")
+      assert_equal (+"foo\u20AC").force_encoding("ASCII-8BIT"), StripAttributes.strip((+"foo\u20AC ").force_encoding("ASCII-8BIT"))
     end
   end
 end


### PR DESCRIPTION
To be compatible with MRI 3.4 we have to explicitly make some string literals frozen. This PR adapts tests, adds 3.4-specific changes to CI and makes `""` and `" "` literals in `lib/strip_attributes.rb` frozen.

ref: https://bugs.ruby-lang.org/issues/20205