### PR TITLE
Avoid string mutation for Ruby 3.4

### DIFF
--- a/lib/strip_attributes.rb
+++ b/lib/strip_attributes.rb
@@ -59,21 +59,21 @@ module StripAttributes
     replace_newlines = options[:replace_newlines]
     regex            = options[:regex]
 
-    value.gsub!(regex, "") if regex
+    value = value.gsub(regex, "") if regex
 
-    if MULTIBYTE_SUPPORTED && Encoding.compatible?(value, MULTIBYTE_SPACE)
-      value.gsub!(/\A#{MULTIBYTE_SPACE}+|#{MULTIBYTE_SPACE}+\z/, "")
+    value = if MULTIBYTE_SUPPORTED && Encoding.compatible?(value, MULTIBYTE_SPACE)
+      value.gsub(/\A#{MULTIBYTE_SPACE}+|#{MULTIBYTE_SPACE}+\z/, "")
     else
-      value.strip!
+      value.strip
     end
 
-    value.gsub!(/[\r\n]+/, " ") if replace_newlines
+    value = value.gsub(/[\r\n]+/, " ") if replace_newlines
 
     if collapse_spaces
-      if MULTIBYTE_SUPPORTED && Encoding.compatible?(value, MULTIBYTE_BLANK)
-        value.gsub!(/#{MULTIBYTE_BLANK}+/, " ")
+      value = if MULTIBYTE_SUPPORTED && Encoding.compatible?(value, MULTIBYTE_BLANK)
+        value.gsub(/#{MULTIBYTE_BLANK}+/, " ")
       else
-        value.squeeze!(" ")
+        value.squeeze(" ")
       end
     end
 

--- a/test/strip_attributes_test.rb
+++ b/test/strip_attributes_test.rb
@@ -428,7 +428,7 @@ class StripAttributesTest < Minitest::Test
       skip "multi-byte characters not supported by this version of Ruby" unless StripAttributes::MULTIBYTE_SUPPORTED
 
       assert_equal "foo", StripAttributes.strip("\u200A\u200B foo\u200A\u200B ")
-      assert_equal "foo\u20AC".force_encoding("ASCII-8BIT"), StripAttributes.strip("foo\u20AC ".force_encoding("ASCII-8BIT"))
+      assert_equal "foo\u20AC".b, StripAttributes.strip("foo\u20AC ".b)
     end
   end
 end


### PR DESCRIPTION
I see multiple pull requests that attempt to address this issue. Here is my version. It avoids the frozen string literal warnings by using non-mutative string methods instead.

Fixes #76