### PR TITLE
Call .dup on string before modifying it in-place.

### DIFF
--- a/lib/strip_attributes.rb
+++ b/lib/strip_attributes.rb
@@ -54,6 +54,8 @@ module StripAttributes
     return value unless value.is_a?(String)
     return value if value.frozen?
 
+    value = value.dup
+
     allow_empty      = options[:allow_empty]
     collapse_spaces  = options[:collapse_spaces]
     replace_newlines = options[:replace_newlines]

--- a/test/strip_attributes_test.rb
+++ b/test/strip_attributes_test.rb
@@ -428,7 +428,10 @@ class StripAttributesTest < Minitest::Test
       skip "multi-byte characters not supported by this version of Ruby" unless StripAttributes::MULTIBYTE_SUPPORTED
 
       assert_equal "foo", StripAttributes.strip("\u200A\u200B foo\u200A\u200B ")
-      assert_equal "foo\u20AC".force_encoding("ASCII-8BIT"), StripAttributes.strip("foo\u20AC ".force_encoding("ASCII-8BIT"))
+
+      str = "foo\u20AC".dup
+
+      assert_equal str.force_encoding("ASCII-8BIT"), StripAttributes.strip(str.force_encoding("ASCII-8BIT"))
     end
   end
 end


### PR DESCRIPTION
Prevents Ruby 3.4 frozen string warnings.

Fixes https://github.com/rmm5t/strip_attributes/issues/76.