### PR TITLE
Limit concurrent-ruby in build matrix for activemodels <7.1

### DIFF
--- a/gemfiles/activemodel-6.0.gemfile
+++ b/gemfiles/activemodel-6.0.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "activemodel", "~> 6.0.0"
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec path: "../"

--- a/gemfiles/activemodel-6.1.gemfile
+++ b/gemfiles/activemodel-6.1.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "activemodel", "~> 6.1.0"
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec path: "../"

--- a/gemfiles/activemodel-7.0.gemfile
+++ b/gemfiles/activemodel-7.0.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "activemodel", "~> 7.0.0"
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec path: "../"


### PR DESCRIPTION
concurrent-ruby 1.3.5+ doesn't work with Rails <= 7.0